### PR TITLE
Adjust stylesheet scrape rate limit to be more reliable

### DIFF
--- a/emotescraper/bmscraper/scraper.py
+++ b/emotescraper/bmscraper/scraper.py
@@ -115,6 +115,9 @@ class BMScraper(FileNameUtils):
         logger.debug("Downloading images using {} threads".format(self.workers))
         workpool = WorkerPool(size=self.workers)
 
+        # we are not constrained by the Reddit rate limits here 
+        rate_limit = TokenBucket(15, 30)
+
         # cache emotes
         key_func = lambda e: e['background-image']
         with self.mutex:
@@ -129,7 +132,7 @@ class BMScraper(FileNameUtils):
                     workpool.put(DownloadJob(self._requests,
                                              image_url,
                                              retry=5,
-                                             rate_limit_lock=self.rate_limit_lock,
+                                             rate_limit_lock=rate_limit,
                                              callback=self._callback_download_image,
                                              **{'image_path': file_path}))
 

--- a/emotescraper/scrape.py
+++ b/emotescraper/scrape.py
@@ -48,7 +48,9 @@ scraper.legacy_subreddits = legacy_subreddits
 scraper.image_blacklist = image_blacklist
 scraper.nsfw_subreddits = nsfw_subreddits
 scraper.emote_info = emote_info
-scraper.rate_limit_lock = TokenBucket(15, 30)
+
+#these values seem to be quite stable (occasional 429 does happen though, because nothing makes sense)
+scraper.rate_limit_lock = TokenBucket(1, 6)
 scraper.tags_data = requests.get(CDN_ORIGIN + "/data/tags.js").json()
 
 start = time.time()


### PR DESCRIPTION
Reddit has some weird rate limits and currently some subreddits end up being skipped (eg. /r/mortdoesreddit ) due to this. Read somewhere that the rate limit could be 100 requests per 600 seconds, probably not quite but was a good enough estimate that made scrape more reliable after setting values to 1 token per 6 seconds as it removed bursts.

I also kept the image download rate the same as currently, since there was no issue with that. Scrape (assuming no new emotes to be downloaded) now takes about 30 minutes.

These rates were tested without an Reddit account and with scraper being converted to python3.